### PR TITLE
bundle for SSR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
 /public/build/
+/build
 
 .DS_Store

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-require('svelte/register');
-const App = require("./src/App.svelte").default;
+const App = require("./build/App.js");
 
 const data = App.render({});
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import { terser } from 'rollup-plugin-terser';
 
 const production = !process.env.ROLLUP_WATCH;
 
-export default {
+const client = {
 	input: 'src/main.js',
 	output: {
 		sourcemap: true,
@@ -52,6 +52,27 @@ export default {
 		clearScreen: false
 	}
 };
+
+const server = {
+	input: 'src/App.svelte',
+	output: {
+		file: 'build/App.js',
+		format: 'cjs',
+		sourcemap: true
+	},
+	plugins: [
+		svelte({
+			generate: 'ssr'
+		}),
+		resolve({
+			browser: true,
+			dedupe: ['svelte']
+		}),
+		commonjs()
+	]
+};
+
+export default [client, server];
 
 function serve() {
 	let started = false;


### PR DESCRIPTION
`svelte/register` only works in the very simplest cases. as soon as a component needs to import ESM, you need to bundle.